### PR TITLE
[test] Add failing test for null masked_bank_account_number (PLS-1746)

### DIFF
--- a/e2e/src/subscriptionsController.spec.ts
+++ b/e2e/src/subscriptionsController.spec.ts
@@ -1,6 +1,9 @@
 import {
+  AllVaults,
   BankAccountType,
   CardType,
+  CustomersController,
+  PaymentProfilesController,
   PaymentType,
   ProductFamiliesController,
   ProductFamilyResponse,
@@ -267,6 +270,60 @@ describe('Subscriptions Controller', () => {
           state: SubscriptionStateFilter.Active,
         });
       expect(subscriptionsResponse.result.length >= 4).toBeTruthy();
+    });
+
+    test('should list subscriptions with null masked_bank_account_number from vault token payment profile', async () => {
+      // Create a customer
+      const client = createClient();
+      const customersController = new CustomersController(client);
+      const paymentProfilesController = new PaymentProfilesController(client);
+
+      const customerResponse = await customersController.createCustomer({
+        customer: {
+          firstName: 'VaultToken',
+          lastName: 'Test',
+          email: `vault-${uid()}@example.com`,
+        },
+      });
+      const customerId = customerResponse.result.customer.id || 0;
+
+      // Create a payment profile using vault token — no real bank account number,
+      // so masked_bank_account_number will be null in API responses
+      const paymentProfileResponse =
+        await paymentProfilesController.createPaymentProfile({
+          paymentProfile: {
+            customerId,
+            currentVault: AllVaults.Bogus,
+            vaultToken: '999999',
+            paymentType: PaymentType.BankAccount,
+            bankName: 'Vault Bank',
+          },
+        });
+      const paymentProfileId =
+        paymentProfileResponse.result.paymentProfile.id;
+
+      // Create subscription with the vault-token-based payment profile
+      const subscriptionResponse =
+        await subscriptionsController.createSubscription({
+          subscription: {
+            productId: productResponse01.product.id,
+            customerId,
+            paymentProfileId,
+          },
+        });
+      expect(subscriptionResponse.statusCode).toBe(201);
+      const subscriptionId =
+        subscriptionResponse.result.subscription?.id || 0;
+
+      // listSubscriptions should parse without schema validation error
+      // even when masked_bank_account_number is null
+      const listResponse =
+        await subscriptionsController.listSubscriptions({});
+      const found = listResponse.result.find(
+        (item) => item.subscription?.id === subscriptionId
+      );
+      expect(found).toBeDefined();
+      expect(found?.subscription?.bankAccount).toBeDefined();
     });
   });
 


### PR DESCRIPTION
**Ticket:** https://maxioevolution.atlassian.net/browse/PLS-1746

**Summary:**

Adds a failing e2e test that proves the SDK throws a schema validation error when `masked_bank_account_number` is `null` in the API response. This happens when a payment profile is created via vault token (no real bank account number).

**What the new test does:**

- Creates a subscription with a vault-token-based bank account payment profile (`AllVaults.Bogus` + `vaultToken`)
- Calls `listSubscriptions`
- SDK throws: `Expected value to be of type 'string' but found 'object'. Given value: null. Path: payment_profile › masked_bank_account_number`

**Next steps:**

1. Fix `masked_bank_account_number` nullability in the OpenAPI spec (`developer-portal`)
2. Regenerate SDK
3. Verify this test passes

